### PR TITLE
Fixed some Links

### DIFF
--- a/content/docs/about/kubedag.md
+++ b/content/docs/about/kubedag.md
@@ -24,7 +24,7 @@ The project is committed to the following design ideals:
 
 ## Architecture
 
-KubeDag implements the workflow as [Execution](/docs/about/execution) using [Kubernetes CRD](/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions).
+KubeDag implements the workflow as [Execution](/docs/about/execution) using [Kubernetes CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions).
 
 KubeDag consists of three main components:
 * Execution controller

--- a/content/docs/started/getting-started-minikube.md
+++ b/content/docs/started/getting-started-minikube.md
@@ -170,9 +170,9 @@ This takes a couple minutes as it will talk to the hypervisor and create a VM wi
 
 Notes:
 
-1. These are the minimum recommended settings on the VM created by minikube for kubeflow deployment. You are free to adjust them **higher** based on your host machine
+1. These are the minimum recommended settings on the VM created by minikube for KubeGene deployment. You are free to adjust them **higher** based on your host machine
 capabilities and workload requirements.
-1. Using certain hypervisors might require you to set --vm-driver option [specifying the driver](https://github.com/kubernetes/minikube/blob//docs/drivers.md)
+1. Using certain hypervisors might require you to set --vm-driver option [specifying the driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md)
 you want to use.
 
 In case, you have the default minikube VM already created (following detailed installation instructions), please use the following to update the VM.


### PR DESCRIPTION
Issue: some links are not working as expected.

In https://kubegene.io/docs/about/kubedag/ 
Kubernetes CRD. link is wrong

In https://kubegene.io/docs/started/getting-started-minikube/
specifying the driver  link is wrong