### PR TITLE
moved to dynamic-concurrency folder and Updated size limit

### DIFF
--- a/content/docs/design/dynamic-concurrency/dynamic-concurrency.md
+++ b/content/docs/design/dynamic-concurrency/dynamic-concurrency.md
@@ -80,7 +80,8 @@ Job-a:
 
 # **get_result  function** 
 
-get_result (job-target,Split)
+* getresult is only available in the vars_iter field.
+* get_result (job-target,Split)
 
 Examples:
 
@@ -142,10 +143,10 @@ type Task struct {
  ```
 * After getting the result from the depend job then need to update the  execution tasks by creating dynamic job 
 
-* get the result by using the log API
+* get the result by using the log API and response data size limitation is 1K
 
 ```go
-res, err := e.kubeClient.CoreV1().Pods(job.Namespace).GetLogs(podList.Items[0].Name, nil).Param("limitBytes", "1024").DoRaw() 
+res, err := e.kubeClient.CoreV1().Pods(job.Namespace).GetLogs(podList.Items[0].Name, nil).Param("limitBytes", SIZELIMIT).DoRaw() 
 ```
 
 * after updating the  execution tasks need to update/recreate the graph

--- a/content/docs/design/dynamic-concurrency/dynamic-concurrency.md
+++ b/content/docs/design/dynamic-concurrency/dynamic-concurrency.md
@@ -15,12 +15,12 @@ In the process of genome sequencing, it is often necessary to read the contents 
 For example, after splitting the sample file by a fixed size, you need to get all the set of split file names. Or the previous step is distributed processing, and you need to get the sum of the results.
 
 
-current KubeGene Supports the static concurrency as shown below
+current KubeGene supports the static concurrency as shown below
 
 ```yaml
 Job-2:
-    Command: echo ${1} ${2}
-    Vars_iter:
+    command: echo ${1} ${2}
+    vars_iter:
       - [A, B, C] # <==== Note here, the number of concurrent representations (range) for ${1}
       - [0, 1]
 
@@ -29,8 +29,8 @@ In the above KubeGene syntax, [A, B, C] indicates that the number of concurrency
 
 ```yaml
 Job-2:
-    Command: echo ${1} ${2}
-    Vars_iter:
+    command: echo ${1} ${2}
+    vars_iter:
       - get_result(job-1) # <==== Note that the array result is dynamically "calculated" based on the stdout of the specified task(job-1).
       - [0, 1]
 
@@ -39,16 +39,16 @@ Job-2:
 The result that is actually obtained is the standard output of the specified step.
 For example, the stdout of job-1 is "1 2 3 4", then the result of the previous step is
 
-    Vars_iter:
-      - ["1 2 3 4"] 
+    vars_iter:
+      - ["1 2 3 4"]
 Note that there is only one member in the array. That is, there is only one concurrency.
 If we want, each one as a concurrency, you can add a "segment" to split . See the get_result function for the specific syntax .
 
-    Vars_iter:
-      - get_result( job-1, " ")   
+    vars_iter:
+      - get_result( job-1, " ")
 Will get:
 
-    Vars_iter:
+    vars_iter:
       - ["1", "2", "3", "4"] 
 This gives four concurrencies, each variable being "1", "2", "3", "4". Among them, the separator is an arbitrary string.
 After having the get_result function, if you need to implement the task concurrently and dynamically according to the result of the previous step
@@ -58,30 +58,30 @@ After having the get_result function, if you need to implement the task concurre
 Example:
 
 ```yaml
-Job-list:  
-  Tool: nginx:new-latest
-  Commands: #   <== (1) List files in the directory
+Job-list:
+    tool: nginx:new-latest
+    commands: #   <== (1) List files in the directory
     - |
       For i in `ls ${sfs}/${output-folder}`; do
         Echo ${i}
       Done
-Job-a:  
-  Tool: nginx:new-latest
-  Options_iter:
-    Command: echo ${output-prefix}job-c-${item} >> ${sfs}/${output-folder}/${1}; # <== (3) Iterative concurrency, replace variable $ {1}
-    Vars_iter:
+Job-a:
+ commands_iter:
+    tool: nginx:new-latest
+    command: echo ${output-prefix}job-c-${item} >> ${sfs}/${output-folder}/${1}; # <== (3) Iterative concurrency, replace variable $ {1}
+    vars_iter:
       - get_result(job-list, '\n') # <== (2) Output the job-list, one by one, and split into concurrent arrays
-  Depends:
+  depends:
     - target: job-list
-      Type: whole
+      type: whole
 
 ```
 
 
 # **get_result  function** 
 
-* getresult is only available in the vars_iter field.
-* get_result (job-target,Split)
+* get_result is only available in the vars_iter field.
+* get_result (Job-target,Split)
 
 Examples:
 
@@ -110,17 +110,17 @@ List-4.txt
 The iterative execution command is obtained by the get_result function.
 ```yaml
 Job-a:
-  Options_iter:
-    Command: echo ${1} ${2}
-    Vars_iter:
+  commands_iter:
+    command: echo ${1} ${2}
+    vars_iter:
       - [A, B, C]
       - get_result( job-1, "\n") # <==== Note here, the number of concurrent representations (range) for ${2}
 Then when you perform the job-a step, you will actually get the following results:
 
 Job-a:
-  Options_iter:
-    Command: echo ${1} ${2}
-    Vars_iter:
+  commands_iter:
+    command: echo ${1} ${2}
+    vars_iter:
       - [A, B, C]
       - ["list-1.txt", "list-2.txt", "list-3.txt", "list-4.txt"] # <==== Note here, the concurrency of ${2} Quantity (range)
 ```


### PR DESCRIPTION
What this PR does / why we need it: 
Just moved the dynamic-concurrency  design to dynamic-concurrency  folder and updated the result size limit.